### PR TITLE
ci: adding ci runner to run unit tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,28 @@
+name: Ruby CI
+
+on:
+  push:
+    branches-ignore: [ master ]
+  pull_request: 
+    branches: [ master ]
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ 2.6, 2.7 ]
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install proper bundler gem
+        run: gem install bundler -v 1.17.2
+      - name: Install Ruby gems
+        run: bundle install
+      - name: Run rake spec tasks
+        run: bundle exec rspec


### PR DESCRIPTION
This will add CI runners for the current version of Ruby (2.6) and next up (2.7) that run the `rspec` rake task.